### PR TITLE
Mircea: Reading the version from git tags using git describe

### DIFF
--- a/hacienda.gemspec
+++ b/hacienda.gemspec
@@ -1,9 +1,11 @@
 require 'date'
-patch_number = ENV['GO_PIPELINE_COUNTER'] || 0
+require_relative 'util/sem_ver'
+
+include SemVer
 
 Gem::Specification.new do |s|
   s.name        = 'hacienda'
-  s.version     = "0.1.25.#{patch_number}"
+  s.version     = SemVer.version_from_git
   s.date        = Date.today.to_s
   s.summary     = 'Hacienda is a RESTful service to manage content'
   s.description = 'Hacienda is a RESTful service to manage content'

--- a/spec/util/sem_ver_spec.rb
+++ b/spec/util/sem_ver_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../spec_helper'
+require_relative '../../util/sem_ver'
+
+include SemVer
+
+describe SemVer do
+
+  it 'should leave the major.minor.patch as it is' do
+     expect(SemVer::from_raw_git_describe("1.2.7")).to eq "1.2.7"
+  end
+
+  it 'should leave the major.minor.patch as it is for multidigits' do
+     expect(SemVer::from_raw_git_describe("5.32.17")).to eq "5.32.17"
+  end
+
+  it 'should use +build.xx.sha instead of .sha' do
+    expect(SemVer::from_raw_git_describe("0.21.7-123-ed56234a")).to eq "0.21.7.ed56234a"
+  end
+
+end

--- a/util/sem_ver.rb
+++ b/util/sem_ver.rb
@@ -1,0 +1,10 @@
+module SemVer
+
+  def SemVer.from_raw_git_describe(git_version)
+    git_version.sub(/(.*)-(\d*)-(.*)/, '\\1.\\3')
+  end
+
+  def SemVer.version_from_git
+    from_raw_git_describe `git describe --tags origin/master`
+  end
+end


### PR DESCRIPTION
As per https://github.com/www-thoughtworks-com/hacienda/issues/10 changed the versioning.

Used [git describe] (http://git-scm.com/docs/git-describe) to determine the exact version. Instead of the proposed semantic versioning (which is not suported by rubygems) used 'major.minor.patch.sha'